### PR TITLE
feat: add user color setting, better label positioning

### DIFF
--- a/scripts/actionIcon.js
+++ b/scripts/actionIcon.js
@@ -34,7 +34,7 @@ function actionIconGetSegmentLabel(wrapped, segment, distance) {
         if (useDifficult) {
             if (segment.teleport || segment.cumulativeCost === 0) return label;
             if (!(segment.distance === segment.cost && (!segment.last || distance === segment.cumulativeCost))) {
-                let difficultLabel = `⚠ ${ Math.round(segment.cost * 100) / 100 }${ !!units ? ' ' + units : '' } ${ segment.last ? '[' + Math.round(this.totalCost * 100) / 100 + (units ? ' ' + units : '') + ']' : '' }`;
+                let difficultLabel = `\u26A0\uFE0F ${ Math.round(segment.cost * 100) / 100 }${ !!units ? ' ' + units : '' } ${ segment.last ? '[' + Math.round(this.totalCost * 100) / 100 + (units ? ' ' + units : '') + ']' : '' }`;
                 
                 label = showOriginal ? `${label} | ${difficultLabel}` : difficultLabel;
             }


### PR DESCRIPTION
consider label render side and move it appropriately to the side to no overlap with the token itself 
add user color option for label